### PR TITLE
Insert rows

### DIFF
--- a/private/qresults-list.rkt
+++ b/private/qresults-list.rkt
@@ -229,6 +229,11 @@
     (init-field pref-tag)
     (init parent
           [label ""]
+          [style-list '(single
+                variable-columns
+                clickable-headers
+                column-headers
+                reorderable-headers)]
           ;; A popup-menu% to be popped up when the user right-clicks on a
           ;; row.
           [right-click-menu #f])
@@ -370,12 +375,7 @@
        [parent the-pane]
        [choices '()]
        [callback lb-callback]
-       [style '(multiple
-                ;single
-                variable-columns
-                clickable-headers
-                column-headers
-                reorderable-headers)]
+       [style style-list]
        [columns '("")]))
 
     ;; Set a default file name to be used by `on-interactive-export-data` --

--- a/private/qresults-list.rkt
+++ b/private/qresults-list.rkt
@@ -20,6 +20,7 @@
 
 (require racket/gui/base racket/class racket/math file/md5
          racket/list racket/match
+         handy/list-utils
          "utilities.rkt"
          "widget-utilities.rkt"
          "edit-dialog-base.rkt"
@@ -513,7 +514,7 @@
       ;(displayln "in get-selected-row-indexes")
       (let ((selected-items (send the-list-box get-selections)))
         (if (null? selected-items) #f selected-items)))
-    
+
     ;; Return the data corresponding to ROW-INDEX.  This is equivalent to
     ;; (list-ref the-data (get-selected-row-index)), but possibly more
     ;; efficient.
@@ -547,32 +548,13 @@
         (send the-list-box set-selection row-index)
         (send the-list-box set-first-visible-item row-index)))
 
-;This function is from StackOverflow
-;https://stackoverflow.com/questions/16630702/what-racket-function-can-i-use-to-insert-a-value-into-an-arbitrary-position-with
-(define (insert-at lst pos x)
-  (define-values (before after) (split-at lst pos))
-  (append before (cons x after)))
 
-
-    ;;Add a new row at a given row index
-    (define/public (add-row-at new-data row-index)
-        (set! the-data
-            (insert-at the-data row-index new-data)
-            )
+    (define/public (add-rows-at new-data #:row-index [row-index  (- (send the-list-box get-number) 1)])
+      (for ([row new-data])
+        (set! the-data  (insert-at the-data (list  row) row-index)))
       (refresh-contents)
       (send the-list-box set-selection row-index)
-      (send the-list-box set-first-visible-item row-index)
-      )
-
-(define/public (add-rows-at new-data
-                            #:row-index [row-index  (- (send the-list-box get-number) 1)])
-  ;Default insertion point is the end of the table.
-
-  (for ([row new-data]) (set! the-data  (insert-at the-data row-index row)))
-  (refresh-contents)
-  (send the-list-box set-selection row-index)
-  (send the-list-box set-first-visible-item row-index)
-  )
+      (send the-list-box set-first-visible-item row-index))
 
     ;; Delete the row at ROW-INDEX.
     (define/public (delete-row row-index)
@@ -604,4 +586,3 @@
     ;; selected
     (define/public (on-select row-index row-data)
       #f)))
-

--- a/private/qresults-list.rkt
+++ b/private/qresults-list.rkt
@@ -548,15 +548,11 @@
     ;;Add a new row at a given row index
     (define/public (add-row-at new-data row-index)
       ;Build a new set of rows
-      (displayln the-data)
+      ;(displayln the-data)
       (set! the-data
-            ;(append the-data (list new-data))
             (insert-at the-data row-index new-data)
             )
-      (displayln the-data)
-      ;
-      ;(lb-clear the-list-box)
-      ;(send/apply the-list-box set the-data)
+      ;(displayln the-data)
       (refresh-contents)
       )
 

--- a/private/qresults-list.rkt
+++ b/private/qresults-list.rkt
@@ -272,7 +272,7 @@
                  (data (in-list the-data)))
              (lb-fill-row the-list-box row-num formatters data))))))
 
-    (define (refresh-contents-1 row-num data)
+    (define (refresh-contents-1 row-num data) ;Looks like the point of this is to refresh only one row rather than the whole table as refresh-contents does.
       (let ((formatters (get-column-formatters)))
         (lb-fill-row the-list-box row-num formatters data)))
 
@@ -538,6 +538,29 @@
         (send the-list-box set-selection row-index)
         (send the-list-box set-first-visible-item row-index)))
 
+;This function is from StackOverflow
+;https://stackoverflow.com/questions/16630702/what-racket-function-can-i-use-to-insert-a-value-into-an-arbitrary-position-with 
+(define (insert-at lst pos x)
+  (define-values (before after) (split-at lst pos))
+  (append before (cons x after)))
+
+
+    ;;Add a new row at a given row index
+    (define/public (add-row-at new-data row-index)
+      ;Build a new set of rows
+      (displayln the-data)
+      (set! the-data
+            ;(append the-data (list new-data))
+            (insert-at the-data row-index new-data)
+            )
+      (displayln the-data)
+      ;
+      ;(lb-clear the-list-box)
+      ;(send/apply the-list-box set the-data)
+      (refresh-contents)
+      )
+
+
     ;; Delete the row at ROW-INDEX.
     (define/public (delete-row row-index)
       (set! the-data
@@ -563,7 +586,5 @@
     ;; Can be overriden if the user wants to be notified when an item is
     ;; selected
     (define/public (on-select row-index row-data)
-      #f)
-
-    ))
+      #f)))
 

--- a/private/qresults-list.rkt
+++ b/private/qresults-list.rkt
@@ -3,7 +3,7 @@
 ;; qresults-list.rkt -- a sophisticated list box control, see qresults-list%
 ;;
 ;; This file is part of qresults-list -- enhanced list-box% control
-;; Copyright (c) 2019, 2020 Alex Harsányi <AlexHarsanyi@gmail.com>
+;; Copyright (c) 2019 Alex Harsányi <AlexHarsanyi@gmail.com>
 ;;
 ;; This program is free software: you can redistribute it and/or modify it
 ;; under the terms of the GNU Lesser General Public License as published by
@@ -191,7 +191,7 @@
              (send control get-label))))
     ))
 
-
+
 ;;....................................................... qresults-list% ....
 
 ;; Holds information about a column of data in a qresults-list% 
@@ -229,18 +229,14 @@
     (init-field pref-tag)
     (init parent
           [label ""]
-          ;; Type of selection allowed for the underlying list-box% object and
-          ;; can be one of 'single 'multiple or 'extended. For the meaning of
-          ;; each value, see the documentation for the list-box% style
-          ;; initialization field.
-          [selection-type 'single]
+          [style-list '(single
+                variable-columns
+                clickable-headers
+                column-headers
+                reorderable-headers)]
           ;; A popup-menu% to be popped up when the user right-clicks on a
           ;; row.
           [right-click-menu #f])
-
-    ;; TODO: export this class with a proper contract attached.
-    (unless (member selection-type '(single multiple extended))
-      (error (format "bad qresults-list% selection-type: ~a" selection-type)))
 
     (super-new)
 
@@ -320,15 +316,7 @@
                          (if sort-descending? string>? string<?))
                         (#t
                          (if sort-descending? > <)))))
-        (set! the-data
-              (sort the-data
-                    ;; Make sure our comparison function can handle #f, which
-                    ;; we use to mark non-existent data.
-                    (lambda (a b)
-                      (cond ((not b) #t)
-                            ((not a) #f)
-                            (#t (cmp a b))))
-                    #:key key)))
+        (set! the-data (sort the-data cmp #:key key)))
 
       ;; Update the list-box in place (no rows are added/deleted)
       (refresh-contents)
@@ -387,12 +375,7 @@
        [parent the-pane]
        [choices '()]
        [callback lb-callback]
-       [style (cons
-               selection-type
-               '(variable-columns
-                 clickable-headers
-                 column-headers
-                 reorderable-headers))]
+       [style style-list]
        [columns '("")]))
 
     ;; Set a default file name to be used by `on-interactive-export-data` --
@@ -515,14 +498,13 @@
       (let ((selected-items (send the-list-box get-selections)))
         (if (null? selected-items) #f (car selected-items))))
 
-
     ;; Return the indexs of selected rows, or #f is no row is
     ;; selected.
     (define/public (get-selected-row-indexes)
       ;(displayln "in get-selected-row-indexes")
       (let ((selected-items (send the-list-box get-selections)))
         (if (null? selected-items) #f selected-items)))
-
+    
     ;; Return the data corresponding to ROW-INDEX.  This is equivalent to
     ;; (list-ref the-data (get-selected-row-index)), but possibly more
     ;; efficient.
@@ -549,7 +531,6 @@
 
     ;; Add a new row to the end of the list.
     (define/public (add-row data)
-
       (send the-list-box append "")
       (set! the-data (append the-data (list data)))
       (let ((row-index (- (send the-list-box get-number) 1)))
@@ -558,7 +539,7 @@
         (send the-list-box set-first-visible-item row-index)))
 
 ;This function is from StackOverflow
-;https://stackoverflow.com/questions/16630702/what-racket-function-can-i-use-to-insert-a-value-into-an-arbitrary-position-with 
+;https://stackoverflow.com/questions/16630702/what-racket-function-can-i-use-to-insert-a-value-into-an-arbitrary-position-with
 (define (insert-at lst pos x)
   (define-values (before after) (split-at lst pos))
   (append before (cons x after)))

--- a/private/qresults-list.rkt
+++ b/private/qresults-list.rkt
@@ -387,16 +387,12 @@
        [parent the-pane]
        [choices '()]
        [callback lb-callback]
-<<<<<<< HEAD
-       [style style-list]
-=======
        [style (cons
                selection-type
                '(variable-columns
                  clickable-headers
                  column-headers
                  reorderable-headers))]
->>>>>>> b680a09a8e83cc72fb306e3d9a8ebaff91a7040d
        [columns '("")]))
 
     ;; Set a default file name to be used by `on-interactive-export-data` --
@@ -553,6 +549,7 @@
 
     ;; Add a new row to the end of the list.
     (define/public (add-row data)
+
       (send the-list-box append "")
       (set! the-data (append the-data (list data)))
       (let ((row-index (- (send the-list-box get-number) 1)))

--- a/private/qresults-list.rkt
+++ b/private/qresults-list.rkt
@@ -371,7 +371,7 @@
        [choices '()]
        [callback lb-callback]
        [style '(multiple
-                single
+                ;single
                 variable-columns
                 clickable-headers
                 column-headers
@@ -498,6 +498,13 @@
       (let ((selected-items (send the-list-box get-selections)))
         (if (null? selected-items) #f (car selected-items))))
 
+    ;; Return the indexs of selected rows, or #f is no row is
+    ;; selected.
+    (define/public (get-selected-row-indexes)
+      ;(displayln "in get-selected-row-indexes")
+      (let ((selected-items (send the-list-box get-selections)))
+        (if (null? selected-items) #f selected-items)))
+    
     ;; Return the data corresponding to ROW-INDEX.  This is equivalent to
     ;; (list-ref the-data (get-selected-row-index)), but possibly more
     ;; efficient.

--- a/private/qresults-list.rkt
+++ b/private/qresults-list.rkt
@@ -569,6 +569,10 @@
     (define/public (get-row-count)
       (send the-list-box get-number))
 
+    ;; Return the numer of rows in the list box that are selected.
+    (define/public (get-selected-row-count)
+      (length (send the-list-box get-selections)))
+
     ;; Clear the contents of the listbox.
     (define/public (clear)
       (send the-list-box clear)


### PR DESCRIPTION
Changes in this branch support the ability to insert one or more new rows at a chosen place in a table.  In particular, this allows a shortcut found in some popular spreadsheets like OpenOffice Calc and Microsoft Excel where you can insert a number of rows by selecting a number of existing rows and then selecting "insert before/after selection."  The number of new rows inserted will equal the number of rows selected.

The function insert-at may not really belong in qresults-list.rkt.  It may be better to put it in a list utilities package.  