### PR TITLE
Added the ability to insert rows at a specified place in a table.

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -1,5 +1,8 @@
 #lang racket/base
 
+; pointless comment to test ability to pull
+
+
 ;; main.rkt -- main entry point for the package
 ;;
 ;; This file is part of qresults-list -- enhanced list-box% control

--- a/private/qresults-list.rkt
+++ b/private/qresults-list.rkt
@@ -229,6 +229,11 @@
     (init-field pref-tag)
     (init parent
           [label ""]
+          [style-list '(single
+                variable-columns
+                clickable-headers
+                column-headers
+                reorderable-headers)]
           ;; A popup-menu% to be popped up when the user right-clicks on a
           ;; row.
           [right-click-menu #f])
@@ -370,12 +375,7 @@
        [parent the-pane]
        [choices '()]
        [callback lb-callback]
-       [style '(multiple
-                ;single
-                variable-columns
-                clickable-headers
-                column-headers
-                reorderable-headers)]
+       [style style-list]
        [columns '("")]))
 
     ;; Set a default file name to be used by `on-interactive-export-data` --

--- a/private/qresults-list.rkt
+++ b/private/qresults-list.rkt
@@ -548,15 +548,11 @@
     ;;Add a new row at a given row index
     (define/public (add-row-at new-data row-index)
       ;Build a new set of rows
-      (displayln the-data)
+      ;(displayln the-data)
       (set! the-data
-            ;(append the-data (list new-data))
             (insert-at the-data row-index new-data)
             )
-      (displayln the-data)
-      ;
-      ;(lb-clear the-list-box)
-      ;(send/apply the-list-box set the-data)
+      ;(displayln the-data)
       (refresh-contents)
       )
 

--- a/private/qresults-list.rkt
+++ b/private/qresults-list.rkt
@@ -272,7 +272,7 @@
                  (data (in-list the-data)))
              (lb-fill-row the-list-box row-num formatters data))))))
 
-    (define (refresh-contents-1 row-num data)
+    (define (refresh-contents-1 row-num data) ;Looks like the point of this is to refresh only one row rather than the whole table as refresh-contents does.
       (let ((formatters (get-column-formatters)))
         (lb-fill-row the-list-box row-num formatters data)))
 
@@ -538,6 +538,29 @@
         (send the-list-box set-selection row-index)
         (send the-list-box set-first-visible-item row-index)))
 
+;This function is from StackOverflow
+;https://stackoverflow.com/questions/16630702/what-racket-function-can-i-use-to-insert-a-value-into-an-arbitrary-position-with 
+(define (insert-at lst pos x)
+  (define-values (before after) (split-at lst pos))
+  (append before (cons x after)))
+
+
+    ;;Add a new row at a given row index
+    (define/public (add-row-at new-data row-index)
+      ;Build a new set of rows
+      (displayln the-data)
+      (set! the-data
+            ;(append the-data (list new-data))
+            (insert-at the-data row-index new-data)
+            )
+      (displayln the-data)
+      ;
+      ;(lb-clear the-list-box)
+      ;(send/apply the-list-box set the-data)
+      (refresh-contents)
+      )
+
+
     ;; Delete the row at ROW-INDEX.
     (define/public (delete-row row-index)
       (set! the-data
@@ -563,7 +586,5 @@
     ;; Can be overriden if the user wants to be notified when an item is
     ;; selected
     (define/public (on-select row-index row-data)
-      #f)
-
-    ))
+      #f)))
 

--- a/private/qresults-list.rkt
+++ b/private/qresults-list.rkt
@@ -387,16 +387,12 @@
        [parent the-pane]
        [choices '()]
        [callback lb-callback]
-<<<<<<< HEAD
-       [style style-list]
-=======
        [style (cons
                selection-type
                '(variable-columns
                  clickable-headers
                  column-headers
                  reorderable-headers))]
->>>>>>> b680a09a8e83cc72fb306e3d9a8ebaff91a7040d
        [columns '("")]))
 
     ;; Set a default file name to be used by `on-interactive-export-data` --
@@ -553,6 +549,7 @@
 
     ;; Add a new row to the end of the list.
     (define/public (add-row data)
+
       (send the-list-box append "")
       (set! the-data (append the-data (list data)))
       (let ((row-index (- (send the-list-box get-number) 1)))

--- a/private/qresults-list.rkt
+++ b/private/qresults-list.rkt
@@ -371,7 +371,7 @@
        [choices '()]
        [callback lb-callback]
        [style '(multiple
-                single
+                ;single
                 variable-columns
                 clickable-headers
                 column-headers
@@ -498,6 +498,13 @@
       (let ((selected-items (send the-list-box get-selections)))
         (if (null? selected-items) #f (car selected-items))))
 
+    ;; Return the indexs of selected rows, or #f is no row is
+    ;; selected.
+    (define/public (get-selected-row-indexes)
+      ;(displayln "in get-selected-row-indexes")
+      (let ((selected-items (send the-list-box get-selections)))
+        (if (null? selected-items) #f selected-items)))
+    
     ;; Return the data corresponding to ROW-INDEX.  This is equivalent to
     ;; (list-ref the-data (get-selected-row-index)), but possibly more
     ;; efficient.

--- a/private/qresults-list.rkt
+++ b/private/qresults-list.rkt
@@ -569,6 +569,10 @@
     (define/public (get-row-count)
       (send the-list-box get-number))
 
+    ;; Return the numer of rows in the list box that are selected.
+    (define/public (get-selected-row-count)
+      (length (send the-list-box get-selections)))
+
     ;; Clear the contents of the listbox.
     (define/public (clear)
       (send the-list-box clear)


### PR DESCRIPTION
This is useful to be able to implement the typical shortcut to insert multiple rows equal to the number of selected rows in the GUI, as done by Excel and LibreOffice Calc.  Also, handy/list-utils is included in order to get a function for manipulating the table data.